### PR TITLE
Allow decompressing gzip file with any extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.vscode/
 .vscode-test/
 *.vsix
 sample/

--- a/package.json
+++ b/package.json
@@ -35,19 +35,15 @@
 		"commands": [
 			{
 				"command": "gz.decompress",
-				"title": "gzip decompress",
+				"title": "GZIP: Decompress",
 				"icon": {
 					"light": "./images/gz-icon.svg",
 					"dark": "./images/gz-icon-dark.svg"
 				}
 			},
 			{
-				"command": "gz.decompress.plain",
-				"title": "gzip decompress to plain"
-			},
-			{
 				"command": "gz.dialogopen",
-				"title": "Show content of the selected .gz in an Open dialog"
+				"title": "GZIP: Decompress multiple files"
 			}
 		],
 		"menus": {
@@ -61,10 +57,6 @@
 			"explorer/context": [
 				{
 					"command": "gz.decompress",
-					"when": "resourceExtname == .gz"
-				},
-				{
-					"command": "gz.decompress.plain",
 					"when": "resourceExtname == .gz"
 				}
 			],

--- a/src/extension.js
+++ b/src/extension.js
@@ -20,8 +20,7 @@ function activate(context) {
 	console.log('Congratulations, your extension "gzipdecompressor" is now active!', process.platform);
 
 	const myScheme = 'gz.decompress';
-	const logExt = '.log';
-	const gzExt = '.gz';
+
 	const myProvider = new class {
 		constructor() {
 			// emitter and its event
@@ -29,11 +28,8 @@ function activate(context) {
 			this.onDidChange = this.onDidChangeEmitter.event;
 		}
 
-		async provideTextDocumentContent(uri, isPlain) {
-			uri = uri.path.substr(logExt.length * -1) == logExt ? uri.path.slice(0, logExt.length * -1) : uri.path;
-			uri += gzExt;
-			let fileData = await this.readFile(uri);
-			return fileData;
+		async provideTextDocumentContent(uri) {
+			return await this.readFile(vscode.Uri.file(uri.path).fsPath);
 		}
 
 		async readFile(fileUri) {
@@ -57,51 +53,51 @@ function activate(context) {
 		}
 	};
 
-	async function decompressLog(uri) {
-		decompress(false, uri)
-	}
-
-	async function decompressPlain(uri) {
-		decompress(true, uri)
-	}
-
-	async function decompress(isPlain, uri) {
+	async function decompress(uri) {
 		if (uri == undefined) {
 			let w = vscode.window;
-			if (w.activeTextEditor == undefined
-				|| w.activeTextEditor.document.uri.path.substr(gzExt.length) != gzExt) {
-				uri = await vscode.window.showInputBox({
-					prompt: "Enter value in gzip",
-					placeHolder: "address",
-					value: vscode.workspace.rootPath
+			if (w.activeTextEditor == undefined) {
+				uri = await w.showOpenDialog({
+					canSelectFiles: true,
+					canSelectFolders: false,
+					canSelectMany: false,
+					filters: {
+						'GZIP files': ['gz'],
+						'Any files': ['*'],
+					}
 				});
-				uri = vscode.Uri.file(uri == undefined ? '' : uri);
+
+				if (uri != undefined) uri = uri[0];
+				else return;
 			} else {
 				uri = w.activeTextEditor.document.uri;
 			}
 		};
-		let path = process.platform == 'win32' ? uri.path.substr(1).replace(/\//g, '\\') : uri.path;
-		let newUri = vscode.Uri.parse(myScheme + ':' + path.slice(0, gzExt.length * -1) + (isPlain ? '' : logExt));
+		let newUri = vscode.Uri.parse(myScheme + ':' + uri.path);
 		let doc = await vscode.workspace.openTextDocument(newUri);
 		await vscode.window.showTextDocument(doc, { preview: false });
 	}
 
 	context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(myScheme, myProvider));
 
-	context.subscriptions.push(vscode.commands.registerCommand('gz.decompress', decompressLog));
-	context.subscriptions.push(vscode.commands.registerCommand('gz.decompress.plain', decompressPlain));
+	context.subscriptions.push(vscode.commands.registerCommand('gz.decompress', decompress));
 
-    context.subscriptions.push(vscode.commands.registerCommand('gz.dialogopen', () => {
-        vscode.window.showOpenDialog({canSelectMany: true, canSelectFolders: false, filters: {'gz': ['gz']}}).then(fileUris => {
+	context.subscriptions.push(vscode.commands.registerCommand('gz.dialogopen', () => {
+		vscode.window.showOpenDialog({
+			canSelectMany: true,
+			canSelectFolders: false,
+			filters: {
+				'GZIP files': ['gz'],
+				'Any files': ['*'],
+			}
+		}).then(fileUris => {
 			if (fileUris)
 				fileUris.forEach(function (fileUri) {
 					vscode.commands.executeCommand('gz.decompress', fileUri);
 				});
-        });
-    }));
+		});
+	}));
 }
-
-exports.activate = activate;
 
 // this method is called when your extension is deactivated
 function deactivate() { }


### PR DESCRIPTION
It's the first step for #4.

## Changes

+ Allow decompressing gzip file with any extensions, not just `.gz` files.
+ Rename commands to be consistent with other extensions' commands.
+ Remove decompress to log file command and decompress to plain text command. Instead, the decompress command will open decompressed window with the original file name and the original file extension. This allows the user to map the language based on opened file extension.

## TODOs

+ Update extension instructions and demos.
+ Peek the opened file and check if GZIP magic number is in the header. If so, show the decompress button.

### Decompress a single file demo

https://user-images.githubusercontent.com/8206622/129021193-ca044883-ee61-446a-b496-d7368782bee3.mp4

### Decompress multiple files demo

https://user-images.githubusercontent.com/8206622/129022056-0181fd6d-165d-4cd6-aeb3-238ca8813ed6.mp4
